### PR TITLE
Eo detail

### DIFF
--- a/app/controllers/api/v1/executive_orders_controller.rb
+++ b/app/controllers/api/v1/executive_orders_controller.rb
@@ -1,10 +1,4 @@
 class Api::V1::ExecutiveOrdersController < ApplicationController
-
-  # def index
-  #   executive_orders = ExecutiveOrderGateway.five_most_recent 
-  #   render json: ExecutiveOrderSerializer.new(executive_orders)
-  # end
-
   def index
     executive_orders = ExecutiveOrderGateway.current_administration_eos
     render json: ExecutiveOrderSerializer.new(executive_orders)
@@ -16,8 +10,9 @@ class Api::V1::ExecutiveOrdersController < ApplicationController
   end
 
   def show 
-    executive_order = ExecutiveOrderDetailGateway.find_specific_eo
+    document_number = params[:document_number]
+    executive_order = ExecutiveOrderDetailGateway.find_specific_eo(document_number)
+    # binding.pry
     render json: ExecutiveOrderSerializer.new(executive_order)
   end
-
 end 

--- a/app/controllers/api/v1/executive_orders_controller.rb
+++ b/app/controllers/api/v1/executive_orders_controller.rb
@@ -16,7 +16,8 @@ class Api::V1::ExecutiveOrdersController < ApplicationController
   end
 
   def show 
-    
+    executive_order = ExecutiveOrderDetailGateway.find_specific_eo
+    render json: ExecutiveOrderSerializer.new(executive_order)
   end
 
 end 

--- a/app/controllers/api/v1/executive_orders_controller.rb
+++ b/app/controllers/api/v1/executive_orders_controller.rb
@@ -15,6 +15,8 @@ class Api::V1::ExecutiveOrdersController < ApplicationController
     render json: ExecutiveOrderSerializer.new(executive_orders)
   end
 
-
+  def show 
+    
+  end
 
 end 

--- a/app/controllers/api/v1/executive_orders_controller.rb
+++ b/app/controllers/api/v1/executive_orders_controller.rb
@@ -10,9 +10,8 @@ class Api::V1::ExecutiveOrdersController < ApplicationController
   end
 
   def show 
-    document_number = params[:document_number]
+    document_number = params[:id]
     executive_order = ExecutiveOrderDetailGateway.find_specific_eo(document_number)
-    # binding.pry
     render json: ExecutiveOrderSerializer.new(executive_order)
   end
 end 

--- a/app/gateways/executive_order_detail_gateway.rb
+++ b/app/gateways/executive_order_detail_gateway.rb
@@ -1,0 +1,26 @@
+class ExecutiveOrderDetailGateway
+  
+  def self.find_specific_eo(document_number)
+    # Rails.cache.fetch("find_specific_eo_#{document_number}", expires_in: 12.hours) do
+      selected_executive_order = hit_endpoint("api/v1/documents/#{document_number}.json")
+  
+      ExecutiveOrder.new(selected_executive_order)
+    # end
+  end
+
+  private
+
+  def self.hit_endpoint(endpoint)
+    response = connect.get(endpoint)
+    parse_data(response)
+  end
+  
+  def self.parse_data(response)
+    binding.pry
+    JSON.parse(response.body, symbolize_names: true)[:results]
+  end
+
+  def self.connect
+    Faraday.new(url: "https://www.federalregister.gov") 
+  end
+end

--- a/app/gateways/executive_order_detail_gateway.rb
+++ b/app/gateways/executive_order_detail_gateway.rb
@@ -1,23 +1,24 @@
 class ExecutiveOrderDetailGateway
   
   def self.find_specific_eo(document_number)
-    # Rails.cache.fetch("find_specific_eo_#{document_number}", expires_in: 12.hours) do
+    Rails.cache.fetch("find_specific_eo_#{document_number}", expires_in: 12.hours) do
+      # binding.pry
       selected_executive_order = hit_endpoint("api/v1/documents/#{document_number}.json")
   
       ExecutiveOrder.new(selected_executive_order)
-    # end
+    end
   end
 
   private
 
   def self.hit_endpoint(endpoint)
     response = connect.get(endpoint)
+    binding.pry
     parse_data(response)
   end
   
   def self.parse_data(response)
-    binding.pry
-    JSON.parse(response.body, symbolize_names: true)[:results]
+    JSON.parse(response.body, symbolize_names: true)
   end
 
   def self.connect

--- a/app/gateways/executive_order_detail_gateway.rb
+++ b/app/gateways/executive_order_detail_gateway.rb
@@ -2,7 +2,6 @@ class ExecutiveOrderDetailGateway
   
   def self.find_specific_eo(document_number)
     Rails.cache.fetch("find_specific_eo_#{document_number}", expires_in: 12.hours) do
-      # binding.pry
       selected_executive_order = hit_endpoint("api/v1/documents/#{document_number}.json")
   
       ExecutiveOrder.new(selected_executive_order)
@@ -13,7 +12,6 @@ class ExecutiveOrderDetailGateway
 
   def self.hit_endpoint(endpoint)
     response = connect.get(endpoint)
-    binding.pry
     parse_data(response)
   end
   

--- a/app/gateways/executive_order_gateway.rb
+++ b/app/gateways/executive_order_gateway.rb
@@ -32,23 +32,6 @@ class ExecutiveOrderGateway
     end
   end
 
-  def self.find_specific_eo (document_number)
-    Rails.cache.fetch("five_most_recent", expires_in: 12.hours) do
-      executive_orders = set_query_params("api/v1/documents.json",{
-        per_page: 1, 
-        conditions: { 
-          presidential_document_type: ["executive_order"], 
-          president: ["donald-trump"],
-          publication_date: { 
-            gte: "2025-01-20"
-          }
-        }
-      })
-  
-      executive_orders.map { |executive_order| ExecutiveOrder.new(executive_order)}
-    end
-  end
-
   private
 
   def self.set_query_params(endpoint, parameters = {})

--- a/app/gateways/executive_order_gateway.rb
+++ b/app/gateways/executive_order_gateway.rb
@@ -17,7 +17,7 @@ class ExecutiveOrderGateway
   def self.current_administration_eos
     Rails.cache.fetch("five_most_recent", expires_in: 12.hours) do
       executive_orders = set_query_params("api/v1/documents.json",{
-        per_page: 100, 
+        per_page: 200, 
         order: "newest",
         conditions: { 
           presidential_document_type: ["executive_order"], 
@@ -28,7 +28,24 @@ class ExecutiveOrderGateway
         }
       })
   
-      executive_order_objects = executive_orders.map { |executive_order| ExecutiveOrder.new(executive_order)}
+      executive_orders.map { |executive_order| ExecutiveOrder.new(executive_order)}
+    end
+  end
+
+  def self.find_specific_eo (document_number)
+    Rails.cache.fetch("five_most_recent", expires_in: 12.hours) do
+      executive_orders = set_query_params("api/v1/documents.json",{
+        per_page: 1, 
+        conditions: { 
+          presidential_document_type: ["executive_order"], 
+          president: ["donald-trump"],
+          publication_date: { 
+            gte: "2025-01-20"
+          }
+        }
+      })
+  
+      executive_orders.map { |executive_order| ExecutiveOrder.new(executive_order)}
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
           get :details, action: :index
         end
       end
-      resources :executive_orders, only: [:index] do
+      resources :executive_orders, only: [:index, :show] do
         collection do
           get :recent
         end

--- a/spec/gateways/executive_order_detail_gateway_spec.rb
+++ b/spec/gateways/executive_order_detail_gateway_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe ExecutiveOrderDetailGateway do
+  VCR.use_cassette("single_eo_executive_order_query") do
+    document_number = 2025-03527
+    selected_executive_order = ExecutiveOrderDetailGateway.find_specific_eo(document_number)
+
+    expect(selected_executive_order).not_to be_empty
+    expect(selected_executive_order[0]).to be_an_instance_of(ExecutiveOrder)
+    expect(selected_executive_order[0].id).to be_a(String)
+    expect(selected_executive_order[0].title).to be_a(String)
+    expect(selected_executive_order[0].document_number).to be_a(String)
+    expect(selected_executive_order[0].html_url).to be_a(String)
+    expect(selected_executive_order[0].pdf_url).to be_a(String)
+    expect(selected_executive_order[0].publication_date).to be_a(String)
+    expect(selected_executive_order.length).to eq(1)
+  end
+end

--- a/spec/gateways/executive_order_detail_gateway_spec.rb
+++ b/spec/gateways/executive_order_detail_gateway_spec.rb
@@ -1,18 +1,19 @@
 require "rails_helper"
 
 RSpec.describe ExecutiveOrderDetailGateway do
-  VCR.use_cassette("single_eo_executive_order_query") do
-    document_number = 2025-03527
-    selected_executive_order = ExecutiveOrderDetailGateway.find_specific_eo(document_number)
-
-    expect(selected_executive_order).not_to be_empty
-    expect(selected_executive_order[0]).to be_an_instance_of(ExecutiveOrder)
-    expect(selected_executive_order[0].id).to be_a(String)
-    expect(selected_executive_order[0].title).to be_a(String)
-    expect(selected_executive_order[0].document_number).to be_a(String)
-    expect(selected_executive_order[0].html_url).to be_a(String)
-    expect(selected_executive_order[0].pdf_url).to be_a(String)
-    expect(selected_executive_order[0].publication_date).to be_a(String)
-    expect(selected_executive_order.length).to eq(1)
+  it "Retrieves a specific Executive Order", :vcr do
+    VCR.use_cassette("single_eo_executive_order_query") do
+      document_number = "2025-03527"
+    
+      selected_executive_order = ExecutiveOrderDetailGateway.find_specific_eo(document_number)
+      
+      expect(selected_executive_order).to be_an_instance_of(ExecutiveOrder)
+      expect(selected_executive_order.id).to be_a(String)
+      expect(selected_executive_order.title).to be_a(String)
+      expect(selected_executive_order.document_number).to be_a(String)
+      expect(selected_executive_order.html_url).to be_a(String)
+      expect(selected_executive_order.pdf_url).to be_a(String)
+      expect(selected_executive_order.publication_date).to be_a(String)
+    end
   end
 end

--- a/spec/requests/api/v1/executive_orders_request_spec.rb
+++ b/spec/requests/api/v1/executive_orders_request_spec.rb
@@ -1,15 +1,62 @@
 require "rails_helper"
 RSpec.describe "Executive Orders Endpoints" , type: :request do
-  it "can retrieve a list of executive orders" do
-    get "/api/v1/executive_orders"
-    binding.pry
-    expect(response).to be_successful
-    expect(response).to eq(200)
-  end
+  describe "Happy Paths" do
+    it "can retrieve a list of executive orders from current adminstration" do
+      VCR.use_cassette("list_of_all_executive_orders_query") do
+        get "/api/v1/executive_orders"
+        
+        expect(response).to be_successful
+        expect(response.status).to eq(200)
+        
+        results = JSON.parse(response.body, symbolize_names: true)[:data]
 
-  # it "can retrieve a list of executive orders" do
-  #   get "/api/v1/executive_orders"
-  #   expect(response).to be_successful
-  #   expect(response).to eq(200)
-  # end
+        expect(results.length).to be > 70
+        expect(results[0][:attributes][:id]).to be_a(String)
+        expect(results[0][:attributes][:title]).to be_a(String)
+        expect(results[0][:attributes][:document_number]).to be_a(String)
+        expect(results[0][:attributes][:html_url]).to be_a(String)
+        expect(results[0][:attributes][:pdf_url]).to be_a(String)
+        expect(results[0][:attributes][:publication_date]).to be_a(String)
+      end
+    end
+
+    it "can retrieve a list of the five most recent executive orders" do
+      VCR.use_cassette("list_of_five_most_recent_executive_orders_query") do
+        get "/api/v1/executive_orders/recent"
+        
+        expect(response).to be_successful
+        expect(response.status).to eq(200)
+        
+        results = JSON.parse(response.body, symbolize_names: true)[:data]
+
+        expect(results.length).to eq(5)
+        expect(results[1][:attributes][:id]).to be_a(String)
+        expect(results[1][:attributes][:title]).to be_a(String)
+        expect(results[1][:attributes][:document_number]).to be_a(String)
+        expect(results[1][:attributes][:html_url]).to be_a(String)
+        expect(results[1][:attributes][:pdf_url]).to be_a(String)
+        expect(results[1][:attributes][:publication_date]).to be_a(String)
+      end
+    end
+
+    it "can retrieve a specific executive order" do
+      VCR.use_cassette("specific_executive_order_query") do
+        # document_number = "2025-03527"
+        get "/api/v1/executive_orders/2025-03527"
+        
+        expect(response).to be_successful
+        expect(response.status).to eq(200)
+        
+        binding.pry
+        result = JSON.parse(response.body, symbolize_names: true)
+
+        expect(result[:attributes][:id]).to be_a(String)
+        expect(result[:attributes][:title]).to be_a(String)
+        expect(result[:attributes][:document_number]).to be_a(String)
+        expect(result[:attributes][:html_url]).to be_a(String)
+        expect(result[:attributes][:pdf_url]).to be_a(String)
+        expect(result[:attributes][:publication_date]).to be_a(String)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/executive_orders_request_spec.rb
+++ b/spec/requests/api/v1/executive_orders_request_spec.rb
@@ -41,21 +41,20 @@ RSpec.describe "Executive Orders Endpoints" , type: :request do
 
     it "can retrieve a specific executive order" do
       VCR.use_cassette("specific_executive_order_query") do
-        # document_number = "2025-03527"
-        get "/api/v1/executive_orders/2025-03527"
+        document_number = "2025-03527"
+        get "/api/v1/executive_orders/#{document_number}" 
         
         expect(response).to be_successful
         expect(response.status).to eq(200)
         
-        binding.pry
-        result = JSON.parse(response.body, symbolize_names: true)
-
-        expect(result[:attributes][:id]).to be_a(String)
-        expect(result[:attributes][:title]).to be_a(String)
-        expect(result[:attributes][:document_number]).to be_a(String)
-        expect(result[:attributes][:html_url]).to be_a(String)
-        expect(result[:attributes][:pdf_url]).to be_a(String)
-        expect(result[:attributes][:publication_date]).to be_a(String)
+        result = JSON.parse(response.body, symbolize_names: true)[:data]
+        
+        expect(result[:attributes][:id]).to eq("2025-03527")
+        expect(result[:attributes][:title]).to eq("Implementing the President's \"Department of Government Efficiency\" Cost Efficiency Initiative")
+        expect(result[:attributes][:document_number]).to eq("2025-03527")
+        expect(result[:attributes][:html_url]).to eq("https://www.federalregister.gov/documents/2025/03/03/2025-03527/implementing-the-presidents-department-of-government-efficiency-cost-efficiency-initiative")
+        expect(result[:attributes][:pdf_url]).to eq("https://www.govinfo.gov/content/pkg/FR-2025-03-03/pdf/2025-03527.pdf")
+        expect(result[:attributes][:publication_date]).to eq("March 03, 2025")
       end
     end
   end


### PR DESCRIPTION
Type of change

  - [x] New feature
  - [ ] Bug Fix

Check the correct boxes

  - [x] This code broke nothing
  - [ ] This code broke some stuff
  - [ ] This code broke everything

Implements/Fixes:

  - This PR adds a show endpoint to the ExecutiveOrdersController, allowing users to retrieve details of a specific executive order by its eo_id. It includes:

- A new route (GET /api/v1/executive_orders/:id)
- Create a new ExecutiveOrderDetailGateway
- Controller action to fetch data via the ExecutiveOrderDetailGateway
- Request tests for the index, recent, and show endpoints

Testing Changes:

  - [x] I have fully tested my code 
  - [x] All tests are passing
  - [ ] Some tests are failing
  - [ ] All tests are failing

  - [ ] No previous tests have been changed
  - [ ] Some previous tests have been changed
  - [ ] All of the previous tests have been changed (Please describe what in the world happened that all of the previous tests needed changing.)

Checklist:

  - [x] I have reviewed my code
  - [x] The code will run locally
  - [ ] My code has no unused/commented out code
  - [ ] I have commented my code, particularly in hard-to-understand areas

(Optional) What questions do you have? Anything specific you want feedback on?

  * 

(For Fun!) Please include a link to a gif [or add an emoji] of your feelings about this branch.

Link: